### PR TITLE
update llvm to biweekly 67

### DIFF
--- a/20260421-ruyisdk-biweekly-67.md
+++ b/20260421-ruyisdk-biweekly-67.md
@@ -24,7 +24,10 @@
 
 
 ## LLVM
-
+- [InstCombine] Fold select of ordered fcmps of fabs over isKnownNeverNaN-selects to a single select https://github.com/llvm/llvm-project/pull/192182
+简化非NaN浮点数的嵌套select指令为单层select
+- https://github.com/topperc/p-ext-intrinsics/pull/6
+修复 riscv p 拓展 intriniscs 文档一些错误
 
 ## V8
 本期提交的patch：


### PR DESCRIPTION
## Summary by Sourcery

Document recent LLVM-related updates in the biweekly report.

Documentation:
- Add note about InstCombine optimization for folding nested selects on non-NaN floating-point comparisons into a single select.
- Document fixes to RISC-V P extension intrinsics documentation errors.