### PR TITLE
add llvm to biweekly 68

### DIFF
--- a/20260506-ruyisdk-biweekly-68.md
+++ b/20260506-ruyisdk-biweekly-68.md
@@ -28,6 +28,25 @@
 
 ## LLVM
 
+- [RISCV][MC] Support experimental Zvdota Family instructions 
+https://github.com/llvm/llvm-project/pull/195069
+为 RISC-V 中的 Zvdota 扩展添加 MC 支持
+正在 review
+
+- [RISCV][MC] Add experimental Zvvmm MC support
+https://github.com/llvm/llvm-project/pull/193956
+为 RISC-V 的 Zvvmm 拓展增加初步的 MC 汇编支持
+已经合并
+
+- [InstCombine] Fold select of ordered fcmps of fabs over NaN-scrubber selects to a single select
+https://github.com/llvm/llvm-project/pull/192182
+将不可能是NaN的嵌套select ordered fcmp fabs 化简为单层select
+已经合并
+
+- [IRBuilder][NFC] Add CreateFAbs helper
+https://github.com/llvm/llvm-project/pull/193421
+在 IRBuilder 中创建并重构代码库中通用的 CreateFAbs 辅助函数
+已经合并
 
 ## V8
 


### PR DESCRIPTION
## Summary by Sourcery

Document recent LLVM-related work in the biweekly report, focusing on new RISC-V MC support and floating-point optimizations.

New Features:
- Note new MC support for RISC-V Zvdota extension in LLVM.
- Record initial MC assembly support for RISC-V Zvvmm extension in LLVM.

Enhancements:
- Highlight LLVM InstCombine optimization that folds nested NaN-safe floating-point selects into a single select.
- Capture the addition and refactoring of a common CreateFAbs helper in LLVM IRBuilder.

Documentation:
- Extend the biweekly report with a new LLVM section summarizing recent upstream patches and their status.