### PR TITLE
QEMU status update for 20260526-ruyisdk-biweekly-69.md

### DIFF
--- a/20260526-ruyisdk-biweekly-69.md
+++ b/20260526-ruyisdk-biweekly-69.md
@@ -127,6 +127,17 @@ https://github.com/riscv/riscv-p-spec/pull/284
 
 ### Go
 
+## 模拟器QEMU
+
+RuyiSDK QEMU新建开发分支develop（目前基于QEMU v11.0.0），未来开发工作将在该分支上进行。
+- https://github.com/ruyisdk/qemu/tree/develop
+
+本期添加了多款CPU Model的支持，包括THead C908/910/920，Spacemit X60，Sifive U74:
+- https://github.com/ruyisdk/qemu/commit/98864cb044304c8f79dd435cdd6142a8d350353c
+- https://github.com/ruyisdk/qemu/commit/3bca67d3a19a19297c60872d572ceea903115f74
+- https://github.com/ruyisdk/qemu/commit/815ff8ad3728c46e538570e4de24126df52fc4e7
+- https://github.com/ruyisdk/qemu/commit/3216cf397cc9d43216b8ec5e67dbbd958c30917c
+
 
 ## 版本测试及遗留问题
 


### PR DESCRIPTION
## Summary by Sourcery

Document QEMU development branch changes and newly supported CPU models in the biweekly RuyiSDK status update.

New Features:
- Add a new QEMU development branch description based on QEMU v11.0.0 for future RuyiSDK work.
- Document newly added QEMU CPU model support for THead C908/C910/C920, Spacemit X60, and SiFive U74 in the status report.

Documentation:
- Extend the biweekly report with a QEMU section outlining the new development branch and recently added CPU model support.