### PR TITLE
Update GCC section with new features and support

### DIFF
--- a/20260609-ruyisdk-biweekly-70.md
+++ b/20260609-ruyisdk-biweekly-70.md
@@ -17,6 +17,9 @@
 ### 基础C库
 
 ### GCC
+分析了 bne/beq immediate 支持，完成了Zibi扩展的GCC实现，
+基于 riscv-isa-manual PR #2369，在Ruyisdk GCC / Binutils工具链上支持Zvbc32e / Zvkgs草案
+完成特权指令扩展Smmtt的第一子扩展Smsdid支持，已更新至Ruyisdk Binutils，正在实现第二子扩展Smmpt部分
 
 ### LLVM
 

--- a/20260609-ruyisdk-biweekly-70.md
+++ b/20260609-ruyisdk-biweekly-70.md
@@ -17,9 +17,9 @@
 ### 基础C库
 
 ### GCC
-分析了 bne/beq immediate 支持，完成了Zibi扩展的GCC实现，
-基于 riscv-isa-manual PR #2369，在Ruyisdk GCC / Binutils工具链上支持Zvbc32e / Zvkgs草案
-完成特权指令扩展Smmtt的第一子扩展Smsdid支持，已更新至Ruyisdk Binutils，正在实现第二子扩展Smmpt部分
+- 分析了 bne/beq immediate 支持，完成了Zibi扩展的GCC实现
+- 基于 riscv-isa-manual PR #2369，在Ruyisdk GCC / Binutils工具链上支持Zvbc32e / Zvkgs草案
+- 完成特权指令扩展Smmtt的第一子扩展Smsdid支持，已更新至Ruyisdk Binutils，正在实现第二子扩展Smmpt部分
 
 ### LLVM
 


### PR DESCRIPTION
分析了 bne/beq immediate 支持，完成了Zibi扩展的GCC实现，基于 riscv-isa-manual PR #2369，在Ruyisdk GCC / Binutils工具链上支持Zvbc32e / Zvkgs草案。完成特权指令扩展Smmtt的第一子扩展Smsdid支持，已更新至Ruyisdk Binutils，正在实现第二子扩展Smmpt部分。

## Summary by Sourcery

Document recent GCC and Binutils support updates for new RISC-V extensions and features in the biweekly report.

New Features:
- Add description of completed GCC implementation for the Zibi extension with bne/beq immediate support.
- Add notes on enabling Zvbc32e and Zvkgs draft support in the Ruyisdk GCC/Binutils toolchain.
- Record support status of the Smmtt privileged extension, including completed Smsdid and in-progress Smmpt sub-extensions in Ruyisdk Binutils.

Documentation:
- Expand the GCC section of the biweekly report with details on newly supported RISC-V extensions and ongoing work.