### PR TITLE
Update GCC part.

### DIFF
--- a/20260623-ruyisdk-biweekly-71.md
+++ b/20260623-ruyisdk-biweekly-71.md
@@ -32,7 +32,7 @@
 
   https://github.com/ruyisdk/riscv-gcc/tree/ziccid
 
-- 协助 compiler-explorer 社区完善了 Binutils 的 trunk 分支，适配了RVA23 Profile支持。
+- 协助 compiler-explorer 社区完善了 Binutils 的 trunk 分支，适配了 RVA23 Profile 支持。
 
   - https://github.com/compiler-explorer/compiler-explorer/pull/8827
   - 示例：https://godbolt.org/z/h49rYT3To

--- a/20260623-ruyisdk-biweekly-71.md
+++ b/20260623-ruyisdk-biweekly-71.md
@@ -18,6 +18,29 @@
 
 ### GCC
 
+- 添加 RISC-V Profiles 支持到工具链 --with-arch 选项，用于构建默认支持特定 profile 的工具链，已提 PR 至 riscv-gnu-toolchain 仓库：
+
+  https://github.com/riscv-collab/riscv-gnu-toolchain/pull/1869
+  
+- 提交了 Zvzip 与 Zvdota/Zvbdota 等 RISC-V 草案扩展的 GNU 工具链支持实现。其中，Zvzip 主要面向向量数据重排、打包/解包等场景；Zvdota/Zvbdota 面向点积与批量点积运算，可支撑 AI 推理/训练、DSP、GEMM/Conv 等核心算子的性能优化。
+
+  - zvzip: https://patchwork.sourceware.org/project/gcc/list/?series=62161&archive=both
+  - zvdota: https://github.com/ruyisdk/riscv-gcc/tree/zvdota
+  - 相关介绍：https://github.com/pz9115/riscv-toolchain-notes/blob/main/talks/2026-riscv-zvdota-zvbdota-introduction/README.md
+
+- 完成并提交 Ziccid 扩展的工具链基础支持，包括扩展识别、依赖解析和架构属性传播:
+
+  https://github.com/ruyisdk/riscv-gcc/tree/ziccid
+
+- 协助 compiler-explorer 社区完善了 Binutils 的 trunk 分支，适配了RVA23 Profile支持。
+
+  - https://github.com/compiler-explorer/compiler-explorer/pull/8827
+  - 示例：https://godbolt.org/z/h49rYT3To
+
+- 协助 RISE-Developer-Infrastructure 工作组开始进行工具链 CI 模块的维护更新，更新了 GCC CI 模块，添加了 gcc-16 CI 部分，移除了 gcc-14 的相关检测
+
+  https://github.com/riseproject-dev/gcc-postcommit-ci/pull/1
+  
 ### LLVM
 
 ### V8


### PR DESCRIPTION
Added support for RISC-V Profiles in the toolchain and various enhancements for GNU toolchain implementations related to RISC-V extensions. Updated CI modules for GCC and contributed to the compiler-explorer community.

## Summary by Sourcery

Document recent GCC-related RISC-V toolchain contributions and infrastructure updates in the biweekly report.

New Features:
- Record addition of RISC-V Profile support via --with-arch in the toolchain configuration.
- Note new GNU toolchain support for RISC-V Zvzip and Zvdota/Zvbdota draft extensions for vector and dot-product workloads.
- Document initial toolchain support for the RISC-V Ziccid extension.

Enhancements:
- Highlight updates to Compiler Explorer binutils trunk for RVA23 profile support.
- Capture maintenance of GCC CI modules in the RISE-Developer-Infrastructure project, including adding gcc-16 and removing gcc-14 checks.

Documentation:
- Expand the biweekly report with references and links to upstream pull requests, branches, and talks for the new RISC-V toolchain work.