### PR TITLE
Update eclipse test status

### DIFF
--- a/20260623-ruyisdk-biweekly-71.md
+++ b/20260623-ruyisdk-biweekly-71.md
@@ -12,6 +12,22 @@
 
 ### 版本测试及遗留问题
 
+Eclipse 插件计划发版测试期间 <https://api.ruyisdk.cn/releases/latest-pm> 500 故障，待测功能无法验证，故相关测试延后了一周。
+
+重新开展测试后发版的 Eclipse 插件测试[报告](https://github.com/ruyisdk-test/ruyisdk-eclipse-plugins-test/tree/v0.1.4-1)。
+
+遗留缺陷：
+
+| 缺陷      | 问题等级 | 备注 |
+| ----------- | ----------- | --- |
+| [命令执行提示框可以任意关闭且无法重新打开 #82](https://github.com/ruyisdk/ruyisdk-eclipse-plugins/issues/82)   | 建议 |   |
+| [虚拟环境建立的项目绑定问题 #84](https://github.com/ruyisdk/ruyisdk-eclipse-plugins/issues/84) | 建议 |  |
+| [安装插件时 Eclipse 提示未签名 #85](https://github.com/ruyisdk/ruyisdk-eclipse-plugins/issues/85) | 建议 |  |
+| [有一些可以自动获取的东西，不需要手动填写 #90](https://github.com/ruyisdk/ruyisdk-eclipse-plugins/issues/90) | 建议 |  |
+| [UI：新闻界面切换仅未读“勾号”不明显 #98](https://github.com/ruyisdk/ruyisdk-eclipse-plugins/issues/98) | 建议 |  |
+| [ruyi-venv中的vnev path需要手动点击右侧列表，显示项目路径 #152](https://github.com/ruyisdk/ruyisdk-eclipse-plugins/issues/152) | 建议 |  |
+| [ruyi-venv名称可以默认设置为ruyi-venv-profile属性 #153](https://github.com/ruyisdk/ruyisdk-eclipse-plugins/issues/153) | 建议 |  |
+
 ## 基础组件
 
 ### 基础C库


### PR DESCRIPTION
## Summary by Sourcery

Document the updated status of Eclipse plugin release testing and its outstanding issues in the biweekly report.

Documentation:
- Add notes about the Eclipse plugin release testing delay due to backend 500 errors and link to the resumed test report.
- List current known Eclipse plugin defects and their severities in the biweekly documentation.