### PR TITLE
Update Go section of 71

### DIFF
--- a/20260623-ruyisdk-biweekly-71.md
+++ b/20260623-ruyisdk-biweekly-71.md
@@ -26,4 +26,17 @@
 
 ### Go
 
+本期提交主线的CL：
+
+- 790080: cmd/compile: support zba extensions for riscv64 | https://go-review.googlesource.com/c/go/+/790080 添加ZBA SSA 支持
+- 789520: cmd/compile: support zbs extensions for riscv64 | https://go-review.googlesource.com/c/go/+/789520 添加ZBS SSA 支持
+
+本期审阅并提出修改意见CL：
+
+- 580276: cmd/compile: support Zba extensions in riscv64 compiler | https://go-review.googlesource.com/c/go/+/580276 沟通后关闭无法进行的CL，移除RVA23合入障碍
+- 579797: cmd/compile: support Zbs extensions in riscv64 compiler | https://go-review.googlesource.com/c/go/+/579797 沟通后关闭无法进行的CL，移除RVA23合入障碍
+- 616095: test/codegen: add tests for combined shift and zero extension on riscv64 | https://go-review.googlesource.com/c/go/+/616095 添加zero extend 位移测试
+- 717980: runtime, cmd/internal/obj/riscv: support spin lock on riscv64 | https://go-review.googlesource.com/c/go/+/717980 要求移除跟随ABIInternal
+- 732700: cmd/internal/obj/riscv: add assembly support of Zfa extension | https://go-review.googlesource.com/c/go/+/732700 添加ZFA 支持
+
 ### QEMU模拟器


### PR DESCRIPTION
## Summary by Sourcery

Update the Go section of the biweekly report to describe recent riscv64-related compiler and runtime contributions and reviews.

New Features:
- Document new riscv64 compiler support for Zba and Zbs extensions and Zfa assembly in the Go toolchain.

Enhancements:
- Highlight reviewed and closed riscv64-related CLs that unblock RVA23 integration and add zero-extension shift tests and spin-lock feedback.