### PR TITLE
Update biweekly report with RISC-V changes

### DIFF
--- a/20260707-ruyisdk-biweekly-72.md
+++ b/20260707-ruyisdk-biweekly-72.md
@@ -19,6 +19,7 @@
 ### GCC
 
 ### LLVM
+- [compiler-rt][msan] Add MSan support for RISC-V 64-bit Linux | https://github.com/llvm/llvm-project/pull/206674 提供RISC-V msan 功能
 
 ### V8
 
@@ -26,4 +27,8 @@
 
 ### Go
 
+- 796060: runtime: enable vgetrandom vDSO support for linux/riscv64 | https://go-review.googlesource.com/c/go/+/796060  开启 vdso 提升 crypto 性能
+- 796100: runtime: use sigaction syscalls when cgo is enabled on riscv64 | https://go-review.googlesource.com/c/go/+/796100 启动sigaction
+
 ### QEMU模拟器
+- target/riscv/kvm: skip FP/Vector sync on KVM_PUT_RUNTIME_STATE 减少寄存器同步压力


### PR DESCRIPTION
Added updates for GCC, LLVM, V8, OpenJDK, Go, and QEMU regarding RISC-V support and performance improvements.

## Summary by Sourcery

Document recent RISC-V support and performance improvements across LLVM, Go, and QEMU in the biweekly report.

Documentation:
- Add LLVM MSan support note for RISC-V 64-bit Linux.
- Record Go runtime improvements for riscv64 around vDSO getrandom and sigaction usage.
- Highlight QEMU RISC-V KVM optimization reducing FP/Vector register sync overhead.