### PR TITLE
Document GCC updates and fixes in biweekly report

### DIFF
--- a/20260707-ruyisdk-biweekly-72.md
+++ b/20260707-ruyisdk-biweekly-72.md
@@ -17,6 +17,9 @@
 ### 基础C库
 
 ### GCC
+- 完成了ruyisdk-gcc 16.1，ruyisdk-binutils 2.46的整合工作，支持多种新扩展及全面的RV Profiles
+  - https://github.com/ruyisdk/riscv-gcc
+  - https://github.com/ruyisdk/riscv-binutils
 - Rebase了Zcmt的Binutils支持，重新设计了link relaxation实现
   - https://sourceware.org/pipermail/binutils/2026-June/149842.html
 - 提交了Zama16b和Ziccamoc扩展的支持patch
@@ -24,7 +27,8 @@
   - https://sourceware.org/pipermail/binutils/2026-June/149848.html
 - 修复了Zvdota扩展的altfmt识别问题，已合入上游
   - https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=cd28fb866379c5dbbe431feb24aa62d369554f80
-
+- 正在推进P扩展的intrinsic支持更新中
+  - https://github.com/ruyisdk/riscv-gcc/pull/12
 ### LLVM
 
 ### V8

--- a/20260707-ruyisdk-biweekly-72.md
+++ b/20260707-ruyisdk-biweekly-72.md
@@ -17,6 +17,13 @@
 ### 基础C库
 
 ### GCC
+- Rebase了Zcmt的Binutils支持，重新设计了link relaxation实现
+  - https://sourceware.org/pipermail/binutils/2026-June/149842.html
+- 提交了Zama16b和Ziccamoc扩展的支持patch
+  - https://sourceware.org/pipermail/binutils/2026-June/149847.html
+  - https://sourceware.org/pipermail/binutils/2026-June/149848.html
+- 修复了Zvdota扩展的altfmt识别问题，已合入上游
+  - https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=cd28fb866379c5dbbe431feb24aa62d369554f80
 
 ### LLVM
 


### PR DESCRIPTION
Updated GCC section with recent changes and fixes.

## Summary by Sourcery

Update the biweekly report to document recent GCC-related changes and fixes.

Documentation:
- Add notes on Zcmt Binutils support rebase and link relaxation redesign in the GCC section of the biweekly report.
- Record submission of patches for Zama16b and Ziccamoc extensions in the GCC section.
- Document the upstream fix for Zvdota extension altfmt recognition in the GCC section.