### PR TITLE
Update GCC support and rebase P extension

### DIFF
--- a/20260721-ruyisdk-biweekly-73.md
+++ b/20260721-ruyisdk-biweekly-73.md
@@ -23,6 +23,11 @@
 ### 基础C库
 
 ### GCC
+提交了Ziccid, Ziccamoc, Ssccfg, Smcdeleg, Smctr, Smsdid, Ssctr, Ssqosid， Svrsw60t59b的扩展支持到gcc上游：
+https://patchwork.sourceware.org/project/gcc/list/?series=63789&state=%2A&archive=both
+
+Rebase了P扩展的gcc工具链支持到gcc-16.1 release分支，后续等待P扩展草案冻结后向上游同步提交：
+https://github.com/ruyisdk/riscv-gcc/tree/p-rebase
 
 ### LLVM
 


### PR DESCRIPTION
Added support for multiple extensions in GCC and rebased P extension support to GCC 16.1 release branch.

## Summary by Sourcery

Document recent GCC extension support submissions and P extension toolchain rebase in the biweekly report.

Documentation:
- Add notes on submitting multiple RISC-V extensions to GCC upstream with reference to the patchwork series.
- Add notes on rebasing GCC P extension toolchain support onto the gcc-16.1 release branch with link to the repository.